### PR TITLE
Fix bool dtype handling in BaseCollector

### DIFF
--- a/src/collectors/base_collector.py
+++ b/src/collectors/base_collector.py
@@ -315,14 +315,16 @@ class BaseCollector(ABC):
         Returns:
             str: The corresponding SQL column type.
         """
-        if pd.api.types.is_integer_dtype(series):
+        # Check boolean dtype before integer to avoid bools being treated as
+        # integers by pandas type checks.
+        if pd.api.types.is_bool_dtype(series):
+            return "BOOLEAN"
+        elif pd.api.types.is_integer_dtype(series):
             return "INTEGER"
         elif pd.api.types.is_float_dtype(series):
             return "FLOAT"
         elif pd.api.types.is_datetime64_any_dtype(series):
             return "DATETIME"
-        elif pd.api.types.is_bool_dtype(series):
-            return "BOOLEAN"
         else:
             # For strings, try to estimate appropriate VARCHAR length
             if series.dtype == 'object':


### PR DESCRIPTION
## Summary
- fix `_infer_sql_type` so boolean Series map to BOOLEAN instead of INTEGER

## Testing
- `pytest -q tests/database/test_engine.py::test_engine_creation_success` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6856845b7cf8832baee39fa85642617b