### PR TITLE
Fix file naming typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ This project implements a comprehensive trading system with modular components f
 │   │   │   ├── `acquirer_multiple.py` – Acquirer’s Multiple value strategy.  
 │   │   │   ├── `buffets_qarp_strat.py` – Buffett’s QARP value strategy.  
 │   │   │   ├── `deep_value_strat.py` – Deep value investing strategy.  
-│   │   │   ├── `dividend_yeild_start.py` – Dividend yield value strategy.  
+│   │   │   ├── `dividend_yield_strat.py` – Dividend yield value strategy.
 │   │   │   ├── `ev_ebidta_private_equity_strat.py` – EV/EBITDA private equity screener.  
 │   │   │   ├── `grahams_defensive_strat.py` – Graham’s defensive value strategy.  
-│   │   │   ├── `greenblatts_earnings_yeild_strat.py` – Greenblatt’s earnings yield strategy.  
+│   │   │   ├── `greenblatts_earnings_yield_strat.py` – Greenblatt’s earnings yield strategy.
 │   │   │   ├── `insider_activist_strat.py` – Insider/activist investor screener.  
 │   │   │   ├── `low_price_sales_start.py` – Low price-to-sales value strategy.  
 │   │   │   ├── `magic_formula_start.py` – Magic Formula value strategy.  

--- a/src/strategies/value/greenblatts_earnings_yield_strat.py
+++ b/src/strategies/value/greenblatts_earnings_yield_strat.py
@@ -1,4 +1,4 @@
-# trading_system/src/strategy/value/greenblatts_earnings_yeild_strat.py
+# trading_system/src/strategy/value/greenblatts_earnings_yield_strat.py
 
 # TODO: Verify
 


### PR DESCRIPTION
## Summary
- rename strategy module to `greenblatts_earnings_yield_strat.py`
- update references in README
- fix docstring path comment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685685a57cfc832bac8c7bb27a54a706