### PR TITLE
Fix start_date comparison in price collector

### DIFF
--- a/src/collectors/price_collector.py
+++ b/src/collectors/price_collector.py
@@ -39,7 +39,8 @@ class PriceCollector(BaseCollector):
                 start_date = latest_date + timedelta(days=1)
                 
                 # Only fetch if we need recent data
-                if start_date.date() >= datetime.now().date():
+                # Use > so today's data is included
+                if start_date.date() > datetime.now().date():
                     logger.debug(f"No new data needed for {ticker}")
                     return
                 


### PR DESCRIPTION
## Summary
- allow fetching today's price data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yfinance')*

------
https://chatgpt.com/codex/tasks/task_e_685685b68030832bae4ad279ee96cd53