### PR TITLE
Fix ticker-level evaluator header

### DIFF
--- a/src/optimizer/ticker_level/performance_evaluator.py
+++ b/src/optimizer/ticker_level/performance_evaluator.py
@@ -1,4 +1,4 @@
-# trading_system/src/optimizer/performance_evaluator.py
+# trading_system/src/optimizer/ticker_level/performance_evaluator.py
 
 """
 Performance metrics calculation module for trading strategy evaluation.


### PR DESCRIPTION
## Summary
- fix module path comment in `ticker_level/performance_evaluator.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy, pandas, yfinance)*

------
https://chatgpt.com/codex/tasks/task_e_685685c22380832bbe7500b312a5c9ad