### PR TITLE
Update tests to use fetch_and_save

### DIFF
--- a/tests/Claude_testCase.py
+++ b/tests/Claude_testCase.py
@@ -243,8 +243,8 @@ def collector(mock_engine):
     return PriceCollector(mock_engine)
 
 @patch('yfinance.Ticker')
-def test_fetch_price_data(mock_ticker, collector):
-    """Test fetching price data."""
+def test_fetch_and_save(mock_ticker, collector):
+    """Test fetching and saving price data."""
     # Setup mock data
     mock_stock = Mock()
     mock_ticker.return_value = mock_stock
@@ -260,7 +260,7 @@ def test_fetch_price_data(mock_ticker, collector):
     mock_stock.history.return_value = mock_data
     
     # Test the fetch
-    collector.fetch_price_data('AAPL')
+    collector.fetch_and_save('AAPL')
     
     # Verify the data was processed
     mock_ticker.assert_called_once_with('AAPL')

--- a/tests/collectors/e2e_test.py
+++ b/tests/collectors/e2e_test.py
@@ -60,11 +60,11 @@ def test_end_to_end_flow(test_engine):
     price_collector = PriceCollector(test_engine)
     
     # First run - initial data
-    price_collector.fetch_price_data(TEST_TICKER)
+    price_collector.fetch_and_save(TEST_TICKER)
     
     # Second run - incremental update
     time.sleep(2)  # Ensure timestamp changes
-    price_collector.fetch_price_data(TEST_TICKER)
+    price_collector.fetch_and_save(TEST_TICKER)
     
     # Verify price data
     with test_engine.connect() as conn:

--- a/tests/collectors/test_price_collector.py
+++ b/tests/collectors/test_price_collector.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock, patch
 from src.collectors.price_collector import PriceCollector
 
 @patch('yfinance.Ticker')
-def test_fetch_price_data(mock_yfinance):
-    """Test price data collection logic."""
+def test_fetch_and_save(mock_yfinance):
+    """Test incremental price data collection logic."""
     mock_stock = MagicMock()
     mock_stock.history.return_value = MagicMock()
     mock_yfinance.return_value = mock_stock
@@ -15,7 +15,7 @@ def test_fetch_price_data(mock_yfinance):
     collector._get_latest_date = lambda *args: None
     collector._save_to_database = MagicMock()
     
-    collector.fetch_price_data("TEST")
+    collector.fetch_and_save("TEST")
     assert collector._save_to_database.called
 
 def test_refresh_data():


### PR DESCRIPTION
## Summary
- adjust collector tests to use `fetch_and_save`
- rename outdated tests to match new API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685685ce1bac832bac0e63eea315007c