### PR TITLE
Fix GARCHX forecast exogenous input

### DIFF
--- a/src/strategies/advanced/garchx_strat.py
+++ b/src/strategies/advanced/garchx_strat.py
@@ -550,9 +550,14 @@ class GarchXStrategyStrategy(BaseStrategy):
             
             # Calculate enhanced out-of-sample performance
             try:
+                # The arch package expects exogenous inputs with shape
+                # (n_vars, horizon, simulations).  Transpose the PCA features so
+                # that the leading dimension corresponds to the number of
+                # regressors and add a singleton simulation dimension.
+                x_fc = X_test_pca.values.T[:, :, np.newaxis]
                 forecast = best_model.forecast(
-                    horizon=len(test_data), 
-                    x=X_test_pca, 
+                    horizon=len(test_data),
+                    x=x_fc,
                     method='simulation',
                     simulations=1000,
                     reindex=False
@@ -1054,14 +1059,18 @@ class GarchXStrategyStrategy(BaseStrategy):
                 columns=[f'pca_{i}' for i in range(n_components)]
             )
             
-            # Create exogenous input for the forecast
-            # Use 2D array with shape (horizon, n_components)
-            X_forecast_array = np.repeat(X_recent_pca.values, horizon, axis=0)
-            
+            # Create exogenous input for the forecast.  When using more than one
+            # exogenous regressor, the arch package expects a 3-D array where the
+            # final dimension represents simulation paths.  Use a single path.
+            # Repeat the last observation across the forecast horizon and
+            # reshape to (n_vars, horizon, 1)
+            x_fc = np.repeat(X_recent_pca.values.T, horizon, axis=1)
+            x_fc = x_fc[:, :, np.newaxis]
+
             # Generate forecast with enhanced error handling
             forecast = model.forecast(
-                horizon=horizon, 
-                x=X_forecast_array, 
+                horizon=horizon,
+                x=x_fc,
                 method='simulation',
                 simulations=1000,
                 reindex=False
@@ -1173,13 +1182,18 @@ class GarchXStrategyStrategy(BaseStrategy):
             last_exog = X_train.iloc[-1:]
             last_exog_pca = pca.transform(last_exog)
 
-            # Create exogenous input for the forecast
-            # Use 2D array with shape (horizon, n_components)
-            X_forecast_array = np.repeat(last_exog_pca, horizon, axis=0)
-            
+            # Create exogenous input for the forecast.  When using multiple
+            # regressors the arch package expects a 3-D array.  Repeat the last
+            # observation across the forecast horizon and add a singleton
+            # simulation dimension.
+            # Repeat the final observation across the forecast horizon and
+            # reshape to (n_vars, horizon, 1)
+            x_fc = np.repeat(last_exog_pca.T, horizon, axis=1)
+            x_fc = x_fc[:, :, np.newaxis]
+
             forecast = best_result.forecast(
-                horizon=horizon, 
-                x=X_forecast_array, 
+                horizon=horizon,
+                x=x_fc,
                 method='simulation',
                 simulations=1000,
                 reindex=False


### PR DESCRIPTION
## Summary
- fix EGARCH forecast usage with multiple exogenous regressors by transposing PCA data and ensuring shape `(n_vars, horizon, 1)`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68569d81d33c832bb9d5b1d9e83905da